### PR TITLE
[mpd widget] Control MPV using MPD widget

### DIFF
--- a/widgets/wibox/mpd/mpd.lua
+++ b/widgets/wibox/mpd/mpd.lua
@@ -271,6 +271,34 @@ local function toggle (mpd)
 end
 
 
+local function pause (mpd)
+  if not mpd.control_mpv then
+    awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
+    update (mpd)
+  else
+    if mpd.infos.state == "play" then
+      awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
+      update (mpd)
+    else
+      local cmd = [[ps aux | awk "$(printf '$2==%d {for(i=11;i<=NF;i++){printf "%%s ", $i}; printf "\\n"}' $(pidof mpv | awk '{print $1}'))"]]
+      spawn.easy_async_with_shell(
+        cmd,
+        function (stdout, stderr, reason, exit_code)
+          socket = string.match (stdout, "%-%-input%-ipc%-server=([^ ]*)")
+          if socket == nil then
+            awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
+            update (mpd)
+          else
+            local cmd = string.format([[echo '{ "command": ["set_property", "pause", true] }' | socat - %s]], socket)
+            awful.spawn.with_shell(cmd)
+          end
+      end)
+    end
+  end
+end
+
+
+
 local function factory (args, theme)
   mpd               = {}
 
@@ -302,6 +330,7 @@ local function factory (args, theme)
   mpd.old_infos     = false
 
   mpd.toggle = toggle
+  mpd.pause = pause
 
   local mpdh = string.format("telnet://%s:%s", mpd.host, mpd.port)
   local echo = string.format("printf \"%sstatus\\ncurrentsong\\nclose\\n\"", mpd.password)

--- a/widgets/wibox/mpd/mpd.lua
+++ b/widgets/wibox/mpd/mpd.lua
@@ -83,23 +83,23 @@ end
 
 
 local function get_cover (mpd)
-      local music_dir     = mpd.music_dir
-      local infos         = mpd.infos
-      local cover_pattern = mpd.cover_pattern
-      local path          = string.format("%s/%s", music_dir, string.match(infos.file, ".*/"))
-      local file = string.format ("%s/%s", music_dir, infos.file)
-      local cover         = string.format("find '%s' -maxdepth 1 -type f | egrep -i -m1 '%s'",
-                                          path:gsub("'", "'\\''"), cover_pattern)
-      local icon = nil
-      -- local f = io.popen (cover, "r")
-      print (mpd.find_cover .. " " .. file)
-      local f = io.popen (mpd.find_cover .. " " .. file, "r")
-      local l = f:read "*a"
-      f:close ()
-      icon = l:gsub ("\n", "")
-      if #icon == 0 then icon = nil end
+  local music_dir     = mpd.music_dir
+  local infos         = mpd.infos
+  local cover_pattern = mpd.cover_pattern
+  local path          = string.format("%s/%s", music_dir, string.match(infos.file, ".*/"))
+  local file = string.format ("%s/%s", music_dir, infos.file)
+  local cover         = string.format("find '%s' -maxdepth 1 -type f | egrep -i -m1 '%s'",
+                                      path:gsub("'", "'\\''"), cover_pattern)
+  local icon = nil
+  -- local f = io.popen (cover, "r")
+  print (mpd.find_cover .. " " .. file)
+  local f = io.popen (mpd.find_cover .. " " .. file, "r")
+  local l = f:read "*a"
+  f:close ()
+  icon = l:gsub ("\n", "")
+  if #icon == 0 then icon = nil end
 
-      return icon
+  return icon
 end
 
 local function notify (mpd, change)

--- a/widgets/wibox/mpd/mpd.lua
+++ b/widgets/wibox/mpd/mpd.lua
@@ -245,7 +245,10 @@ local function update (mpd)
 end
 
 local function toggle (mpd)
-  if mpd.control_mpv then
+  if not mpd.control_mpv then
+    awful.spawn.with_shell("mpc -p " .. mpd.port .. " toggle")
+    update (mpd)
+  else
     if mpd.infos.state == "play" then
       awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
       update (mpd)
@@ -260,7 +263,7 @@ local function toggle (mpd)
             update (mpd)
           else
             local cmd = string.format("echo 'cycle pause' | socat - %s", socket)
-            spawn.easy_async_with_shell(cmd, function (_, _, _, _) end)
+            awful.spawn.with_shell(cmd)
           end
       end)
     end

--- a/widgets/wibox/mpd/mpd.lua
+++ b/widgets/wibox/mpd/mpd.lua
@@ -325,6 +325,87 @@ end
 
 
 
+local function next (mpd)
+  if not mpd.control_mpv then
+    awful.spawn.with_shell("mpc -p " .. mpd.port .. " next")
+    update (mpd)
+  else
+    if mpd.infos.state == "play" then
+      awful.spawn.with_shell("mpc -p " .. mpd.port .. " next")
+      update (mpd)
+    else
+      local cmd = [[ps aux | awk "$(printf '$2==%d {for(i=11;i<=NF;i++){printf "%%s ", $i}; printf "\\n"}' $(pidof mpv | awk '{print $1}'))"]]
+      spawn.easy_async_with_shell(
+        cmd,
+        function (stdout, stderr, reason, exit_code)
+          socket = string.match (stdout, "%-%-input%-ipc%-server=([^ ]*)")
+          if socket == nil then
+            awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
+            update (mpd)
+          else
+            local cmd = string.format([[echo 'playlist_next' | socat - %s]], socket)
+            awful.spawn.with_shell(cmd)
+          end
+      end)
+    end
+  end
+end
+
+
+
+local function prev (mpd)
+  if not mpd.control_mpv then
+    awful.spawn.with_shell("mpc -p " .. mpd.port .. " prev")
+    update (mpd)
+  else
+    if mpd.infos.state == "play" then
+      awful.spawn.with_shell("mpc -p " .. mpd.port .. " prev")
+      update (mpd)
+    else
+      local cmd = [[ps aux | awk "$(printf '$2==%d {for(i=11;i<=NF;i++){printf "%%s ", $i}; printf "\\n"}' $(pidof mpv | awk '{print $1}'))"]]
+      spawn.easy_async_with_shell(
+        cmd,
+        function (stdout, stderr, reason, exit_code)
+          socket = string.match (stdout, "%-%-input%-ipc%-server=([^ ]*)")
+          if socket == nil then
+            awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
+            update (mpd)
+          else
+            local cmd = string.format([[echo 'playlist_prev' | socat - %s]], socket)
+            awful.spawn.with_shell(cmd)
+          end
+      end)
+    end
+  end
+end
+
+
+local function stop (mpd)
+  if not mpd.control_mpv then
+    awful.spawn.with_shell("mpc -p " .. mpd.port .. " stop")
+    update (mpd)
+  else
+    if mpd.infos.state == "play" then
+      awful.spawn.with_shell("mpc -p " .. mpd.port .. " stop")
+      update (mpd)
+    else
+      local cmd = [[ps aux | awk "$(printf '$2==%d {for(i=11;i<=NF;i++){printf "%%s ", $i}; printf "\\n"}' $(pidof mpv | awk '{print $1}'))"]]
+      spawn.easy_async_with_shell(
+        cmd,
+        function (stdout, stderr, reason, exit_code)
+          socket = string.match (stdout, "%-%-input%-ipc%-server=([^ ]*)")
+          if socket == nil then
+            awful.spawn.with_shell("mpc -p " .. mpd.port .. " pause")
+            update (mpd)
+          else
+            local cmd = string.format([[echo 'quit' | socat - %s]], socket)
+            awful.spawn.with_shell(cmd)
+          end
+      end)
+    end
+  end
+end
+
 local function factory (args, theme)
   mpd               = {}
 
@@ -358,6 +439,9 @@ local function factory (args, theme)
   mpd.toggle = toggle
   mpd.pause  = pause
   mpd.play   = play
+  mpd.next   = next
+  mpd.prev   = prev
+  mpd.stop   = stop
 
   local mpdh = string.format("telnet://%s:%s", mpd.host, mpd.port)
   local echo = string.format("printf \"%sstatus\\ncurrentsong\\nclose\\n\"", mpd.password)


### PR DESCRIPTION
Add the possibility, through functions `play`, `pause`, `toggle`, `prev`, `next` and `stop` to control mpd **and**, when an instance of **mpv** is running with option `--input-ipc-server`, to control mpv.

Closes #3 